### PR TITLE
Deny balance with date previous loan

### DIFF
--- a/calculator/serializers.py
+++ b/calculator/serializers.py
@@ -54,11 +54,11 @@ class BalanceSerializer(serializers.Serializer):
     def to_representation(self, obj):
         if not obj["date"]:
             obj["date"] = datetime.now().astimezone(tz=timezone.utc)
-        return {"balance": Loan.objects.get(pk=obj["loan_id"]).get_balance(obj["date"])}
+        return {"balance": self.loan.get_balance(obj["date"])}
     
     def validate(self, data):
+        self.loan = Loan.objects.get(pk=data["loan_id"])
         if data["date"]:
-            loan = Loan.objects.get(pk=data["loan_id"])
-            if data["date"] < loan.date_initial:
+            if data["date"] < self.loan.date_initial:
                 raise serializers.ValidationError("The date should be greater than the initial date loan")
         return data

--- a/calculator/serializers.py
+++ b/calculator/serializers.py
@@ -55,3 +55,10 @@ class BalanceSerializer(serializers.Serializer):
         if not obj["date"]:
             obj["date"] = datetime.now().astimezone(tz=timezone.utc)
         return {"balance": Loan.objects.get(pk=obj["loan_id"]).get_balance(obj["date"])}
+    
+    def validate(self, data):
+        if data["date"]:
+            loan = Loan.objects.get(pk=data["loan_id"])
+            if data["date"] < loan.date_initial:
+                raise serializers.ValidationError("The date should be greater than the initial date loan")
+        return data

--- a/calculator/tests/test_balance_view.py
+++ b/calculator/tests/test_balance_view.py
@@ -62,7 +62,7 @@ class BalanceViewTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {"balance": Decimal("800")})
 
-    def test_get_balance_invalid_date(self):
+    def test_get_balance_without_date(self):
         valid_payload = {"date": ""}
         response = self.client.get(
             reverse('balance', kwargs={'pk': self.loan.pk}),
@@ -75,3 +75,11 @@ class BalanceViewTest(TestCase):
             reverse('balance', kwargs={'pk': '000-0000-0000-0015'})
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_balance_invalid_date(self):
+        valid_payload = {"date": "2019-01-01 03:18Z"}
+        response = self.client.get(
+            reverse('balance', kwargs={'pk': self.loan.pk}),
+            valid_payload
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION

##### What this PR made?
Implemented to deny request get_balance when the date is less than the initial date loan

##### Where could the review begin?
serializer.py

##### How this could be tested manually?
run python manage.py test -v2

##### References
#40 