### PR TITLE
Instalment number added to payment response.data

### DIFF
--- a/calculator/models.py
+++ b/calculator/models.py
@@ -179,6 +179,10 @@ class Payment(models.Model):
         remainder_instalments = loan.term - loan.payment_set.count()
         return (loan.get_balance() / remainder_instalments).quantize(self.CENTS)
 
+    @property
+    def payment_number(self):
+        return self.loan_id.payment_set.count()
+
     def __str__(self):
         return f"Payment(loan_id={self.loan_id}, status={self.status}, date={self.date}, amount={self.amount})"
 

--- a/calculator/serializers.py
+++ b/calculator/serializers.py
@@ -34,7 +34,7 @@ class PaymentSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
     def to_representation(self, obj):
-        return {"Instalment number": obj.payment_number, "payment": obj.status, "received": str(obj.amount), "expected":str(obj.amount_expected)}
+        return {"instalment_number": obj.payment_number, "payment": obj.status, "received": str(obj.amount), "expected":str(obj.amount_expected)}
 
     def validate(self, data):
         loan = data['loan_id']

--- a/calculator/serializers.py
+++ b/calculator/serializers.py
@@ -34,7 +34,7 @@ class PaymentSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
     def to_representation(self, obj):
-        return {"payment": obj.status, "received": str(obj.amount), "expected":str(obj.amount_expected)}
+        return {"Instalment number": obj.payment_number, "payment": obj.status, "received": str(obj.amount), "expected":str(obj.amount_expected)}
 
     def validate(self, data):
         loan = data['loan_id']

--- a/calculator/tests/test_payment_view.py
+++ b/calculator/tests/test_payment_view.py
@@ -46,7 +46,7 @@ class RegisterPaymentTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(
-            response.data, {"Instalment number": 1, "payment": "made", "received": "100.00", "expected": "85.69"})
+            response.data, {"instalment_number": 1, "payment": "made", "received": "100.00", "expected": "85.69"})
 
     def test_register_payment_without_loan(self):
         valid_payload = {"payment": "made",
@@ -111,7 +111,7 @@ class RegisterPaymentTest(TestCase):
             content_type="application/json",
         )
         self.assertEqual(
-            response.data, {"Instalment number": 2, "payment": "made", "received": "85.69", "expected": "85.69"})
+            response.data, {"instalment_number": 2, "payment": "made", "received": "85.69", "expected": "85.69"})
 
     def test_payment_expected_posmissed(self):
         Payment.objects.create(
@@ -129,4 +129,4 @@ class RegisterPaymentTest(TestCase):
             content_type="application/json",
         )
         self.assertEqual(
-            response.data, {"Instalment number": 2, "payment": "made", "received": "85.69", "expected": "93.48"})
+            response.data, {"instalment_number": 2, "payment": "made", "received": "85.69", "expected": "93.48"})

--- a/calculator/tests/test_payment_view.py
+++ b/calculator/tests/test_payment_view.py
@@ -46,7 +46,7 @@ class RegisterPaymentTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(
-            response.data, {"payment": "made", "received": "100.00", "expected": "85.69"})
+            response.data, {"Instalment number": 1, "payment": "made", "received": "100.00", "expected": "85.69"})
 
     def test_register_payment_without_loan(self):
         valid_payload = {"payment": "made",
@@ -111,7 +111,7 @@ class RegisterPaymentTest(TestCase):
             content_type="application/json",
         )
         self.assertEqual(
-            response.data, {"payment": "made", "received": "85.69", "expected": "85.69"})
+            response.data, {"Instalment number": 2, "payment": "made", "received": "85.69", "expected": "85.69"})
 
     def test_payment_expected_posmissed(self):
         Payment.objects.create(
@@ -129,4 +129,4 @@ class RegisterPaymentTest(TestCase):
             content_type="application/json",
         )
         self.assertEqual(
-            response.data, {"payment": "made", "received": "85.69", "expected": "93.48"})
+            response.data, {"Instalment number": 2, "payment": "made", "received": "85.69", "expected": "93.48"})

--- a/docs/loan_system.raml
+++ b/docs/loan_system.raml
@@ -113,7 +113,7 @@ types:
              }      
   Payment_info:
     instalment_number:
-      description: Number to keep track the payment register 
+      description: Number of the last payment registered
       type: number
     status: 
       description: Type of payment

--- a/docs/loan_system.raml
+++ b/docs/loan_system.raml
@@ -112,7 +112,7 @@ types:
               "amount": 85.60
              }      
   Payment_info:
-    Instalment number:
+    instalment_number:
       description: Number to keep track the payment register 
       type: number
     status: 

--- a/docs/loan_system.raml
+++ b/docs/loan_system.raml
@@ -112,6 +112,9 @@ types:
               "amount": 85.60
              }      
   Payment_info:
+    Instalment number:
+      description: Number to keep track the payment register 
+      type: number
     status: 
       description: Type of payment
       type: string


### PR DESCRIPTION
##### What this PR made?
Created a "Instalment number" in response.data for payment payload in order for users to keep track to what instalment the payment is related.

##### Where could the review begin?
serializers.py
calculator/models.py

##### How this could be tested manually?
$ python manage.py test -v2
